### PR TITLE
Allow Frontend Domain to access backend

### DIFF
--- a/API/settings.py
+++ b/API/settings.py
@@ -134,6 +134,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 CORS_ALLOWED_ORIGINS = [
     "https://www.test-cors.org",
     "http://localhost:19006"
+    "https://ws22-23-swepm3ilv-inf-ba-vz-group-2.github.io/App"
 ]
 
 CSRF_TRUSTED_ORIGINS = [

--- a/API/settings.py
+++ b/API/settings.py
@@ -134,7 +134,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 CORS_ALLOWED_ORIGINS = [
     "https://www.test-cors.org",
     "http://localhost:19006"
-    "https://ws22-23-swepm3ilv-inf-ba-vz-group-2.github.io/App"
+    "https://ws22-23-swepm3ilv-inf-ba-vz-group-2.github.io"
 ]
 
 CSRF_TRUSTED_ORIGINS = [

--- a/API/settings.py
+++ b/API/settings.py
@@ -133,7 +133,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOWED_ORIGINS = [
     "https://www.test-cors.org",
-    "http://localhost:19006"
+    "http://localhost:19006",
     "https://ws22-23-swepm3ilv-inf-ba-vz-group-2.github.io"
 ]
 

--- a/API/settings.py
+++ b/API/settings.py
@@ -133,6 +133,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOWED_ORIGINS = [
     "https://www.test-cors.org",
+    "http://localhost:19006"
 ]
 
 CSRF_TRUSTED_ORIGINS = [


### PR DESCRIPTION
Closes #62  
Added the domains for the local and online implementations of the app to the settings.py file (at line 134).